### PR TITLE
Update .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -9,6 +9,10 @@ disable=
     C0114, # missing-module-docstring
     E1102, # pc_api.get_endpoint is not callable (not-callable)
     W0613, # Unused argument 'ctx' (unused-argument)
+    
+# Workaround for the following issue generating inconsistent errors:
+# https://github.com/PyCQA/pylint/issues/5319
+init-hook='import sys; sys.path.append(".")'
 
 [BASIC]
 


### PR DESCRIPTION
## Description

Workaround in pylintrc for issue init-hook='import sys; sys.path.append(".")'
