### PR TITLE
Added usage command and added filter option 

### DIFF
--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -169,7 +169,7 @@ def cli(ctx, very_verbose, verbose, configuration, output, columns=None):
 
 
 def cli_output(data, sort_values=False):
-    """Formatted output"""
+    """ Parse data and format output """
     # Retrieve parameters
     params = click.get_current_context().find_root().params
     if params["columns"]:
@@ -193,8 +193,9 @@ def cli_output(data, sort_values=False):
         if data_frame_normalized.size > 0:
             logging.debug("Using normalized data")
             data_frame = data_frame_normalized
+            # Flatten nested json
+            data_frame = flatten_nested_json_df(data_frame)
 
-        # print(data_frame)
         # Do some optimization on our dataframe
         try:
             data_frame["time"] = pd.to_datetime(data_frame.time)
@@ -203,8 +204,20 @@ def cli_output(data, sort_values=False):
         except Exception:  # pylint:disable=broad-except
             logging.debug("No time field")
 
+        # If column name contains time or lastModified, convert values to datetime
+        for column in data_frame.columns:
+            if "time" in column.lower() or "lastmodified" in column.lower() or "availableAsOf" in column.lower():
+                try:
+                    data_frame[column] = pd.to_datetime(data_frame[column], unit='ms')
+                except Exception as _exc:
+                    logging.debug("Error: %s", _exc)
+                try:
+                    data_frame[column] = pd.to_datetime(data_frame[column], unit='s')
+                except Exception as _exc:
+                    logging.debug("Error: %s", _exc)
+
         # Drop all rows after max_rows
-        data_frame.drop(data_frame.index[settings.max_rows:], inplace=True)
+        data_frame = data_frame.head(settings.max_rows)
 
         # We have a dataframe, output here after we have dropped
         # all but the selected columns
@@ -260,6 +273,37 @@ def cli_output(data, sort_values=False):
         # There is no dataframe, might be just a single value, like version.
         click.echo(data)
         logging.debug("Error ingesting data into dataframe: %s", _exc)
+
+def flatten_nested_json_df(df):
+    """ Flatten nested json in our dataframe """
+    logging.debug("Flatten nested json")
+    df = df.reset_index()
+    s = (df.applymap(type) == list).all()
+    list_columns = s[s].index.tolist()
+    
+    s = (df.applymap(type) == dict).all()
+    dict_columns = s[s].index.tolist()
+    
+    while len(list_columns) > 0 or len(dict_columns) > 0:
+        new_columns = []
+
+        for col in dict_columns:
+            horiz_exploded = pd.json_normalize(df[col]).add_prefix(f'{col}.')
+            horiz_exploded.index = df.index
+            df = pd.concat([df, horiz_exploded], axis=1).drop(columns=[col])
+            new_columns.extend(horiz_exploded.columns) # inplace
+
+        for col in list_columns:
+            logging.debug(f"exploding: {col}")
+            df = df.drop(columns=[col]).join(df[col].explode().to_frame())
+            new_columns.append(col)
+
+        s = (df[new_columns].applymap(type) == list).all()
+        list_columns = s[s].index.tolist()
+
+        s = (df[new_columns].applymap(type) == dict).all()
+        dict_columns = s[s].index.tolist()
+    return df
 
 
 def do_truncate(truncate_this):

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -283,36 +283,37 @@ def cli_output(data, sort_values=False):
         click.echo(data)
         logging.debug("Error ingesting data into dataframe: %s", _exc)
 
-def flatten_nested_json_df(df):
+
+def flatten_nested_json_df(data_frame):
     """ Flatten nested json in our dataframe """
     logging.debug("Flatten nested json")
-    df = df.reset_index()
-    s = (df.applymap(type) == list).all()
-    list_columns = s[s].index.tolist()
-    
-    s = (df.applymap(type) == dict).all()
-    dict_columns = s[s].index.tolist()
-    
+    data_frame = data_frame.reset_index()
+    temp_s = (data_frame.applymap(type) == list).all()
+    list_columns = temp_s[temp_s].index.tolist()
+
+    temp_s = (data_frame.applymap(type) == dict).all()
+    dict_columns = temp_s[temp_s].index.tolist()
+
     while len(list_columns) > 0 or len(dict_columns) > 0:
         new_columns = []
 
         for col in dict_columns:
-            horiz_exploded = pd.json_normalize(df[col]).add_prefix(f'{col}.')
-            horiz_exploded.index = df.index
-            df = pd.concat([df, horiz_exploded], axis=1).drop(columns=[col])
-            new_columns.extend(horiz_exploded.columns) # inplace
+            horiz_exploded = pd.json_normalize(data_frame[col]).add_prefix(f'{col}.')
+            horiz_exploded.index = data_frame.index
+            data_frame = pd.concat([data_frame, horiz_exploded], axis=1).drop(columns=[col])
+            new_columns.extend(horiz_exploded.columns)  # inplace
 
         for col in list_columns:
             logging.debug(f"exploding: {col}")
-            df = df.drop(columns=[col]).join(df[col].explode().to_frame())
+            data_frame = data_frame.drop(columns=[col]).join(data_frame[col].explode().to_frame())
             new_columns.append(col)
 
-        s = (df[new_columns].applymap(type) == list).all()
-        list_columns = s[s].index.tolist()
+        temp_s = (data_frame[new_columns].applymap(type) == list).all()
+        list_columns = temp_s[temp_s].index.tolist()
 
-        s = (df[new_columns].applymap(type) == dict).all()
-        dict_columns = s[s].index.tolist()
-    return df
+        temp_s = (data_frame[new_columns].applymap(type) == dict).all()
+        dict_columns = temp_s[temp_s].index.tolist()
+    return data_frame
 
 
 def do_truncate(truncate_this):

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -141,6 +141,7 @@ Prisma Cloud CLI (version: {0})
 )
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
 @click.option("-vv", "--very_verbose", is_flag=True, help="Enables very verbose mode")
+@click.option("--filter", help="Add search filter")
 @click.option("-o", "--output", type=click.Choice(["text", "csv", "json", "html", "columns"]), default="text")
 @click.option(
     "-c",
@@ -152,7 +153,7 @@ Prisma Cloud CLI (version: {0})
 @click.option("--columns", "columns", help="Select columns for output", default=None)
 @pass_environment
 # pylint: disable=W0613
-def cli(ctx, very_verbose, verbose, configuration, output, columns=None):
+def cli(ctx, very_verbose, verbose, configuration, output, filter, columns=None):
     """Define the command line"""
     ctx.configuration = configuration
     ctx.output = output
@@ -215,6 +216,14 @@ def cli_output(data, sort_values=False):
                     data_frame[column] = pd.to_datetime(data_frame[column], unit='s')
                 except Exception as _exc:
                     logging.debug("Error: %s", _exc)
+
+        # If a filter is set, apply it
+        if params["filter"]:
+            try:
+                data_frame = data_frame.query(params["filter"])
+            except Exception as _exc:
+                logging.error("Error: %s", _exc)
+                exit(1)
 
         # Drop all rows after max_rows
         data_frame = data_frame.head(settings.max_rows)

--- a/prismacloud/cli/api.py
+++ b/prismacloud/cli/api.py
@@ -90,19 +90,19 @@ def read_cli_config_file(config_file_name):
 """ Prisma Cloud API Library Wrapper """
 
 
-def get_endpoint(_self, endpoint, query_params=None, api="cwpp"):
-    """Make a GET request without using an endpoint-specific method"""
+def get_endpoint(_self, endpoint, query_params=None, api="cwpp", request_type="GET"):
+    """Make a request without using an endpoint-specific method"""
     pc_api.configure(map_cli_config_to_api_config())
-    logging.debug("Calling API Endpoint: %s", endpoint)
+    logging.debug("Calling API Endpoint (%s): %s", request_type, endpoint)
     result = None
     if api == "cspm":
-        result = pc_api.execute("GET", endpoint, query_params)
+        result = pc_api.execute(request_type, endpoint, query_params)
     if api == "cwpp":
         if not endpoint.startswith("api"):
             endpoint = "api/v1/%s" % endpoint
-        result = pc_api.execute_compute("GET", endpoint, query_params)
+        result = pc_api.execute_compute(request_type, endpoint, query_params)
     if api == "code":
-        result = pc_api.execute_code_security("GET", endpoint, query_params)
+        result = pc_api.execute_code_security(request_type, endpoint, query_params)
     return result
 
 

--- a/prismacloud/cli/cspm/cmd_usage.py
+++ b/prismacloud/cli/cspm/cmd_usage.py
@@ -9,7 +9,7 @@ from prismacloud.cli.api import pc_api
 def cli(ctx):
     body_params = {
         'accountIds': [],
-        'timeRange': {'type':'relative', 'value': {'unit': 'day', 'amount': 90}}
+        'timeRange': {'type': 'relative', 'value': {'unit': 'day', 'amount': 90}}
         }
     result = pc_api.resource_usage_over_time(body_params=body_params)
     cli_output(result)

--- a/prismacloud/cli/cspm/cmd_usage.py
+++ b/prismacloud/cli/cspm/cmd_usage.py
@@ -1,0 +1,15 @@
+import click
+
+from prismacloud.cli import cli_output, pass_environment
+from prismacloud.cli.api import pc_api
+
+
+@click.command("usage", short_help="[CSPM] Retrieve credits usage information")
+@pass_environment
+def cli(ctx):
+    body_params = {
+        'accountIds': [],
+        'timeRange': {'type':'relative', 'value': {'unit': 'day', 'amount': 90}}
+        }
+    result = pc_api.resource_usage_over_time(body_params=body_params)
+    cli_output(result)

--- a/prismacloud/cli/version.py
+++ b/prismacloud/cli/version.py
@@ -1,1 +1,1 @@
-version = "0.4.9"
+version = "0.4.10"


### PR DESCRIPTION
## Description

* Added usage command to get usage per resource over time
* Added filter option to be able to filter output (based on Pandas query, see https://sparkbyexamples.com/pandas/pandas-dataframe-query-examples/)

## Motivation and Context

* Usage command is helpful to get details on sudden increase or decrease of credit usage
* Having a filtering option (room for improvement) is useful to find relevant rows

## How Has This Been Tested?

The usage command has been tested with:

`pc --columns dataPoints.timeRange.startTime,dataPoints.timeRange.endTime,dataPoints.counts.others.container,dataPoints.counts.others.host,dataPoints.counts.others.serverless,dataPoints.counts.others.waas --filter "\`dataPoints.timeRange.startTime\` >= '2022-03-30' & \`dataPoints.timeRange.startTime\` <= '2022-04-2'" usage`

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/96180461/164307027-c346391a-0217-4dc9-88cb-424ab05a1d69.png)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
