### PR TITLE
Make the CLI available to windows users

### DIFF
--- a/prismacloud/cli/api.py
+++ b/prismacloud/cli/api.py
@@ -5,6 +5,15 @@ import logging
 import os
 import types
 
+try:
+    from pathlib import Path
+    homefolder = str(Path.home())
+except:
+    if "USERPROFILE" in os.environ:
+        homefolder = os.environ["USERPROFILE"]
+    else:
+        homefolder = os.environ["HOME"]
+        
 import click
 import prismacloud.api.version as api_version
 from prismacloud.api import pc_api
@@ -44,7 +53,7 @@ def get_cli_config():
     logging.info(
         "Running prismacloud-cli version %s using prismacloud-api version %s", cli_version.version, api_version.version
     )
-    config_directory = os.environ["HOME"] + "/.prismacloud/"
+    config_directory = homefolder + "/.prismacloud/"
     config_file_name = config_directory + params["configuration"] + ".json"
     if not os.path.exists(config_directory):
         logging.info("Configuration directory does not exist, creating $HOME/.prismacloud")

--- a/prismacloud/cli/api.py
+++ b/prismacloud/cli/api.py
@@ -8,12 +8,13 @@ import types
 try:
     from pathlib import Path
     homefolder = str(Path.home())
-except:
+except Exception as _exc:
+    logging.debug("Searching homefolder with pathlib not working, fallback: %s", _exc)
     if "USERPROFILE" in os.environ:
         homefolder = os.environ["USERPROFILE"]
     else:
         homefolder = os.environ["HOME"]
-        
+
 import click
 import prismacloud.api.version as api_version
 from prismacloud.api import pc_api


### PR DESCRIPTION
With this change the CLI will work on windows environments as the only problem was the use of the HOME variable.

## Description

Changes how the config directory is retrieved to make the tool available to windows users.

## Motivation and Context

I wanted to use the CLI in a windows host.

## How Has This Been Tested?

I've use it with my tenant.


## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
