### PR TITLE
Create config dir if missing

### DIFF
--- a/prismacloud/cli/api.py
+++ b/prismacloud/cli/api.py
@@ -75,6 +75,8 @@ effort policy.
         if any(answer.lower() == f for f in ["yes", 'y']):
             print("Message accepted.")
             # Create file to check next time
+            if not os.path.exists(config_directory):
+                os.mkdir(config_directory)
             with open(community_support_accepted, "w") as _accepted:
                 _accepted.write("Yes")
         else:


### PR DESCRIPTION
## Description

This adds a couple of lines to fix an error at first run:

A test condition to see if the config directory "~/.prismacloud" exists during first run. 
Then `mkdir` said directory.

## Motivation and Context

Documented issue [here](https://github.com/PaloAltoNetworks/prismacloud-cli/issues/79).
Issue is reproducible when the `~/.prismacloud` does not exist

## How Has This Been Tested?

Yes.  This was tested by removing the `~/.prismacloud` directory structure and re-running `pc version`


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.  Commit message only
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
