### PR TITLE
Moved WAAS/firewall audits to "firewall audits" and fixed "container audits" endpoint

### DIFF
--- a/prismacloud/cli/cwpp/cmd_audits.py
+++ b/prismacloud/cli/cwpp/cmd_audits.py
@@ -26,7 +26,7 @@ def container(limit=5):
     from_field = last_hour_date_time.strftime("%Y-%m-%dT%H:%M:%S.%f%z")[:-3] + "Z"
     to_field = "2030-01-01T00:00:00.000Z"
     result = pc_api.get_endpoint(
-        "audits/firewall/app/container", {"from": from_field, "to": to_field, "sort": "time", "reverse": "true"}
+        "audits/runtime/container", {"from": from_field, "to": to_field, "sort": "time", "reverse": "true"}
     )
     cli_output(result)
 

--- a/prismacloud/cli/cwpp/cmd_audits.py
+++ b/prismacloud/cli/cwpp/cmd_audits.py
@@ -30,6 +30,7 @@ def container(limit=5):
     )
     cli_output(result)
 
+
 @click.command()
 @click.option("-l", "--limit", default=5, help="Number of documents to return")
 def firewall(limit=5):
@@ -47,6 +48,7 @@ def firewall(limit=5):
         "audits/firewall/app/container", {"from": from_field, "to": to_field, "sort": "time", "reverse": "true"}
     )
     cli_output(result)
+
 
 cli.add_command(container)
 cli.add_command(firewall)

--- a/prismacloud/cli/cwpp/cmd_audits.py
+++ b/prismacloud/cli/cwpp/cmd_audits.py
@@ -19,7 +19,7 @@ def container(limit=5):
 
     Sample usage:
 
-    pc --config local --columns ruleName,msg,containerName,requestHost,subnet audits container
+    pc --config local --columns os,msg,type,attackType,severity,containerName,hostname audits container
 
     """
     last_hour_date_time = datetime.now() - timedelta(hours=3)
@@ -30,5 +30,23 @@ def container(limit=5):
     )
     cli_output(result)
 
+@click.command()
+@click.option("-l", "--limit", default=5, help="Number of documents to return")
+def firewall(limit=5):
+    """
+
+    Sample usage:
+
+    pc --config local --columns ruleName,msg,containerName,requestHost,subnet audits firewall
+
+    """
+    last_hour_date_time = datetime.now() - timedelta(hours=3)
+    from_field = last_hour_date_time.strftime("%Y-%m-%dT%H:%M:%S.%f%z")[:-3] + "Z"
+    to_field = "2030-01-01T00:00:00.000Z"
+    result = pc_api.get_endpoint(
+        "audits/firewall/app/container", {"from": from_field, "to": to_field, "sort": "time", "reverse": "true"}
+    )
+    cli_output(result)
 
 cli.add_command(container)
+cli.add_command(firewall)


### PR DESCRIPTION
## Description

This change will capture the desired audit event data for containers instead of WAAS Audits.
The audit data for firewall /WAAS will be reassigned to the function "firewall" (e.g. `pc --config local --columns ruleName,msg,containerName,requestHost,subnet audits firewall`)


## Motivation and Context

Reported issue https://github.com/PaloAltoNetworks/prismacloud-cli/issues/81 
`pc -v audits container` produces WAAS audit data instead of runtime audits
"container audits" shows WAAS audits
![Uploading image.png…]()


## How Has This Been Tested?

Comparing data represented in WEBUI on Compute -> Monitor -> Events -> Container Audits
Suggest setting appropriate columns (e.g. `pc --config local --columns os,msg,type,attackType,severity,containerName,hostname audits container`)


Also re-added the firewall audit functionality under the function "firewall"



## Screenshots (if appropriate)
New container audits output:
![Uploading image.png…]()

New firewall audits command:
![Uploading image.png…]()


## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue) 
     Fixed name for current audits code to be firewall audits
- New feature (non-breaking change which adds functionality)
    Added container audit functionality
    
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
