### PR TITLE
refactor for api version 5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,72 +76,65 @@ jobs:
 
       - name: Check connectivity
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
+          echo $PC_URL
           pc --config environment check
 
       - name: Check CWPP version  # (previously exit code 1, should pass now)
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment check
 
       - name: Check usage
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment usage > /dev/null
 
       - name: Check defenders summary
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment defenders summary > /dev/null
 
       - name: Check login events
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment logs audit --type login > /dev/null
 
       - name: Check tags
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment tags > /dev/null
 
       - name: Check cloud names
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment cloud names > /dev/null
 
       - name: Check alert list
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment alert list --unit hour --amount 1 > /dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,72 +76,64 @@ jobs:
 
       - name: Check connectivity
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment check
 
       - name: Check CWPP version  # (previously exit code 1, should pass now)
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment check
 
       - name: Check usage
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment usage > /dev/null
 
       - name: Check defenders summary
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment defenders summary > /dev/null
 
       - name: Check login events
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment logs audit --type login > /dev/null
 
       - name: Check tags
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment tags > /dev/null
 
       - name: Check cloud names
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment cloud names > /dev/null
 
       - name: Check alert list
         env:
-          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
-          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
+          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment alert list --unit hour --amount 1 > /dev/null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,64 +76,72 @@ jobs:
 
       - name: Check connectivity
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment check
 
       - name: Check CWPP version  # (previously exit code 1, should pass now)
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment check
 
       - name: Check usage
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment usage > /dev/null
 
       - name: Check defenders summary
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment defenders summary > /dev/null
 
       - name: Check login events
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment logs audit --type login > /dev/null
 
       - name: Check tags
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment tags > /dev/null
 
       - name: Check cloud names
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment cloud names > /dev/null
 
       - name: Check alert list
         env:
-          PC_URL: ${{ secrets.PC_SAAS_API_ENDPOINT }}
-          PC_IDENTITY: ${{ secrets.PC_ACCESS_KEY }}
-          PC_SECRET: ${{ secrets.PC_SECRET_KEY }}
+          PC_SAAS_API_ENDPOINT: ${{ secrets.PC_SAAS_API_ENDPOINT }}
+          PC_COMPUTE_API_ENDPOINT: ${{ secrets.PC_COMPUTE_API_ENDPOINT }}
+          PC_ACCESS_KEY: ${{ secrets.PC_ACCESS_KEY }}
+          PC_SECRET_KEY: ${{ secrets.PC_SECRET_KEY }}
         run: |
           pc --config environment alert list --unit hour --amount 1 > /dev/null

--- a/README.md
+++ b/README.md
@@ -55,14 +55,13 @@ This process looks like the screenshot below. the prismacloud-cli asks you for s
 Create an access key from Settings then Access key
 Get the path to console from Compute tab, System, Utilities
 
-Create a file into home directory .prismacloud/credentials.json with the following structure
+Create a file into home directory .prismacloud/credentials.json with the following structure.
 
 ```json
 {
-  "api_endpoint": "__REDACTED__",
-  "pcc_api_endpoint": "__REDACTED__",
-  "access_key_id": "__REDACTED__",
-  "secret_key": "__REDACTED__"
+  "url":      "__REDACTED__",
+  "identity": "__REDACTED__",
+  "secret":   "__REDACTED__"
 }
 ```
 
@@ -78,16 +77,14 @@ pc --config demo -o csv policy
 ```
 
 ### Use environment variables for configuration
+
 By setting the environment variables:
 
-PC_SAAS_API_ENDPOINT
-
-PC_COMPUTE_API_ENDPOINT
-
-PC_ACCESS_KEY
-
-PC_SECRET_KEY
-
+```
+PC_URL
+PC_IDENTITY
+PC_SECRET
+```
 
 And then run pc referring to a configuration called environment:
 

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -61,10 +61,9 @@ class Settings(BaseSettings):  # pylint:disable=too-few-public-methods
     max_width: int = 25
     max_levels: int = 2
 
-    pc_saas_api_endpoint: str = False
-    pc_compute_api_endpoint: str = False
-    pc_access_key: str = False
-    pc_secret_key: str = False
+    url: str = False
+    identity: str = False
+    secret: str = False
 
 
 settings = Settings()

--- a/prismacloud/cli/api.py
+++ b/prismacloud/cli/api.py
@@ -156,7 +156,7 @@ def get_cli_config():
             ),
         )
         settings["identity"] = settings.get("identity", settings.pop("access_key_id", settings.pop("username", "")))
-        settings["secret"] = settings.get("secret_key", settings.pop("secret_key", settings.pop("password", "")))
+        settings["secret"] = settings.get("secret", settings.pop("secret_key", settings.pop("password", "")))
         settings["verify"] = settings.get("verify", settings.pop("ca_bundle", False))
         # Normalize URL.
         settings["url"] = pc_util.normalize_api(settings["url"])

--- a/prismacloud/cli/api.py
+++ b/prismacloud/cli/api.py
@@ -8,6 +8,7 @@ import types
 
 try:
     from pathlib import Path
+
     home_directory = str(Path.home())
 except Exception as _exc:  # pylint:disable=broad-except
     logging.debug("Error identifying home directory: %s", _exc)
@@ -28,24 +29,24 @@ import prismacloud.cli.version as cli_version
 
 
 def community_supported():
-    """ If the community supported message has not been accepted yet,
-        it must be shown with the possibility to accept. """
+    """If the community supported message has not been accepted yet,
+    it must be shown with the possibility to accept."""
 
     community_supported_message = """
 # Community Supported
 
 This solution is released under an as-is, best-effort, support policy.
 
-This solution should be seen as community-supported, and Palo Alto Networks will 
-contribute our expertise as and when possible. We do not provide technical support 
-or help in using or troubleshooting the components of this solution through our normal 
-support options such as Palo Alto Networks support teams, Authorized Support Centers, 
-partners, and backline support options. The underlying product (Prisma Cloud) used  
-by these scripts is still supported, but the support is only for the product 
+This solution should be seen as community-supported, and Palo Alto Networks will
+contribute our expertise as and when possible. We do not provide technical support
+or help in using or troubleshooting the components of this solution through our normal
+support options such as Palo Alto Networks support teams, Authorized Support Centers,
+partners, and backline support options. The underlying product (Prisma Cloud) used
+by these scripts is still supported, but the support is only for the product
 functionality itself and not for help in using this solution itself.
 
-Unless explicitly tagged, all projects or work posted in our GitHub organization 
-(at https://github.com/PaloAltoNetworks) or sites other than our official Downloads page 
+Unless explicitly tagged, all projects or work posted in our GitHub organization
+(at https://github.com/PaloAltoNetworks) or sites other than our official Downloads page
 (on https://support.paloaltonetworks.com) are provided under this policy.
 """
 
@@ -57,7 +58,7 @@ Unless explicitly tagged, all projects or work posted in our GitHub organization
     print(community_supported_message)
     answer = input("Enter 'y' or 'yes' to confirm you have read the message above: ")
     print()
-    if any(answer.lower() == f for f in ['y', 'yes']):
+    if any(answer.lower() == f for f in ["y", "yes"]):
         print("Message confirmed.")
         print()
         # Create file to verify that the message already has been accepted.
@@ -77,24 +78,26 @@ Unless explicitly tagged, all projects or work posted in our GitHub organization
 
 
 def read_cli_config_from_environment():
-    """ Read configuration from environment """
+    """Read configuration from environment"""
     logging.debug("Reading configuration from environment")
     settings = {}
     try:
         # API Key              Current CLI ENV VAR           Deprecated CLI ENV VAR(s)
-        settings["name"]     = os.environ.get("PC_NAME",     "")
-        settings["url"]      = os.environ.get("PC_URL",      os.environ.get("PC_SAAS_API_ENDPOINT", os.environ.get("PC_COMPUTE_API_ENDPOINT", "")))
+        settings["name"] = os.environ.get("PC_NAME", "")
+        settings["url"] = os.environ.get(
+            "PC_URL", os.environ.get("PC_SAAS_API_ENDPOINT", os.environ.get("PC_COMPUTE_API_ENDPOINT", ""))
+        )
         settings["identity"] = os.environ.get("PC_IDENTITY", os.environ.get("PC_ACCESS_KEY", ""))
-        settings["secret"]   = os.environ.get("PC_SECRET",   os.environ.get("PC_SECRET_KEY", ""))
-        settings["verify"]   = os.environ.get("PC_VERIFY",   os.environ.get("PC_CA_BUNDLE", False))
+        settings["secret"] = os.environ.get("PC_SECRET", os.environ.get("PC_SECRET_KEY", ""))
+        settings["verify"] = os.environ.get("PC_VERIFY", os.environ.get("PC_CA_BUNDLE", False))
         # Normalize URL.
-        settings["url"]      = pc_util.normalize_api(settings["url"])
+        settings["url"] = pc_util.normalize_api(settings["url"])
         # Mask all except the first two characters of keys when debugging.
         masked_identity = settings["identity"][:3] + "*" * (len(settings["identity"]) - 4)
-        masked_secret   = settings["secret"][:3] + "*"   * (len(settings["secret"]) - 4)
+        masked_secret = settings["secret"][:3] + "*" * (len(settings["secret"]) - 4)
         logging.debug("Environment variable found: PC_URL/PC_SAAS_API_ENDPOINT/PC_COMPUTE_API_ENDPOINT: %s", settings["url"])
         logging.debug("Environment variable found: PC_IDENTITY/PC_ACCESS_KEY: %s", masked_identity)
-        logging.debug("Environment variable found: PC_SECRET/PC_SECRET_KEY: %s",   masked_secret)
+        logging.debug("Environment variable found: PC_SECRET/PC_SECRET_KEY: %s", masked_secret)
     except Exception as exc:  # pylint:disable=broad-except
         logging.debug("Error reading configuration from environment: %s", exc)
     logging.debug("Configuration read from environment")
@@ -146,10 +149,15 @@ def get_cli_config():
     if os.path.exists(config_file_name):
         settings = read_cli_config_file(config_file_name)
         # API Key              Current CLI Key               Deprecated CLI Key(s)
-        settings["url"]      = settings.get('url',           settings.pop('api_endpoint',  settings.pop('api', settings.pop('pcc_api_endpoint', settings.pop('api_compute', '')))))
-        settings["identity"] = settings.get('identity',      settings.pop('access_key_id', settings.pop('username', '')))
-        settings["secret"]   = settings.get('secret_key',    settings.pop('secret_key',    settings.pop('password', '')))
-        settings["verify"]   = settings.get('verify',        settings.pop('ca_bundle', False))
+        settings["url"] = settings.get(
+            "url",
+            settings.pop(
+                "api_endpoint", settings.pop("api", settings.pop("pcc_api_endpoint", settings.pop("api_compute", "")))
+            ),
+        )
+        settings["identity"] = settings.get("identity", settings.pop("access_key_id", settings.pop("username", "")))
+        settings["secret"] = settings.get("secret_key", settings.pop("secret_key", settings.pop("password", "")))
+        settings["verify"] = settings.get("verify", settings.pop("ca_bundle", False))
         # Normalize URL.
         settings["url"] = pc_util.normalize_api(settings["url"])
     else:
@@ -160,13 +168,12 @@ def get_cli_config():
             except Exception as exc:  # pylint:disable=broad-except
                 logging.info("Error creating configuration directory: %s", exc)
         settings = {
-            "url":
-                input("Prisma Cloud Tenant (or Compute Console, if PCCE) URL, eg: api.prismacloud.io or twistlock.example.com"),
-            "identity":
-                input("Access Key (or Compute Username, if PCCE): "),
-            "secret":
-                input("Secret Key (or Compute Password, if PCCE): "),
-            "verify": False
+            "url": input(
+                "Prisma Cloud Tenant (or Compute Console, if PCCE) URL, eg: api.prismacloud.io or twistlock.example.com"
+            ),
+            "identity": input("Access Key (or Compute Username, if PCCE): "),
+            "secret": input("Secret Key (or Compute Password, if PCCE): "),
+            "verify": False,
         }
         # Normalize URL.
         settings["url"] = pc_util.normalize_api(settings["url"])
@@ -175,7 +182,7 @@ def get_cli_config():
 
 
 def map_cli_config_to_api_config():
-    """ Map keys between the Prisma Cloud API package and Prisma Cloud CLI package """
+    """Map keys between the Prisma Cloud API package and Prisma Cloud CLI package"""
     try:
         click.get_current_context()
     except Exception as exc:  # pylint:disable=broad-except
@@ -183,16 +190,21 @@ def map_cli_config_to_api_config():
     settings = get_cli_config()
     return {
         # API Key      Current CLI Key          Deprecated CLI Key(s)
-        "name":        settings.get('name', ''),
-        "url":         settings.get('url',      settings.get('api_endpoint',  settings.get('api', settings.get('pcc_api_endpoint', settings.get('api_compute', ''))))),
-        "identity":    settings.get('identity', settings.get('access_key_id', settings.get('username', ''))),
-        "secret":      settings.get('secret',   settings.get('secret_key',    settings.get('password', ''))),
-        "verify":      settings.get('verify',   settings.get('ca_bundle', False))
+        "name": settings.get("name", ""),
+        "url": settings.get(
+            "url",
+            settings.get(
+                "api_endpoint", settings.get("api", settings.get("pcc_api_endpoint", settings.get("api_compute", "")))
+            ),
+        ),
+        "identity": settings.get("identity", settings.get("access_key_id", settings.get("username", ""))),
+        "secret": settings.get("secret", settings.get("secret_key", settings.get("password", ""))),
+        "verify": settings.get("verify", settings.get("ca_bundle", False)),
     }
 
 
 def read_cli_config_file(config_file_name):
-    """ Read cli configuration from a file """
+    """Read cli configuration from a file"""
     logging.debug("Reading configuration from file: %s", config_file_name)
     config_file_settings = {}
     try:
@@ -205,7 +217,7 @@ def read_cli_config_file(config_file_name):
 
 
 def write_cli_config_file(config_file_name, config_file_settings):
-    """ Write cli configuration to a file """
+    """Write cli configuration to a file"""
     logging.debug("Writing configuration to file: %s", config_file_name)
     try:
         json_string = json.dumps(config_file_settings, sort_keys=True, indent=4)
@@ -220,7 +232,7 @@ def write_cli_config_file(config_file_name, config_file_settings):
 
 
 def get_endpoint(_self, endpoint, query_params=None, api="cwpp", request_type="GET"):
-    """ Make a request without using an endpoint-specific method """
+    """Make a request without using an endpoint-specific method"""
     pc_api.configure(map_cli_config_to_api_config())
     logging.debug("Calling API Endpoint (%s): %s", request_type, endpoint)
     result = None
@@ -228,7 +240,9 @@ def get_endpoint(_self, endpoint, query_params=None, api="cwpp", request_type="G
         try:
             result = pc_api.execute(request_type, endpoint, query_params)
         except Exception as exc:  # pylint:disable=broad-except
-            logging.error("There was an error executing the request. Check if this API (CSPM) is available in your environment.")  # noqa: E501
+            logging.error(
+                "There was an error executing the request. Check if this API (CSPM) is available in your environment."
+            )  # noqa: E501
             logging.error("Please check your config and try again. Error: %s", exc)  # noqa: E501
             sys.exit(1)
     if api == "cwpp":
@@ -237,14 +251,18 @@ def get_endpoint(_self, endpoint, query_params=None, api="cwpp", request_type="G
             try:
                 result = pc_api.execute_compute(request_type, endpoint, query_params)
             except Exception as exc:  # pylint:disable=broad-except
-                logging.error("There was an error executing the request. Check if this API (CWP) is available in your environment.")  # noqa: E501
+                logging.error(
+                    "There was an error executing the request. Check if this API (CWP) is available in your environment."
+                )  # noqa: E501
                 logging.error("Please check your config and try again. Error: %s", exc)  # noqa: E501
                 sys.exit(1)
     if api == "code":
         try:
             result = pc_api.execute_code_security(request_type, endpoint, query_params)
         except Exception as exc:  # pylint:disable=broad-except
-            logging.error("There was an error executing the request. Check if this API (CCS) is available in your environment.")  # noqa: E501
+            logging.error(
+                "There was an error executing the request. Check if this API (CCS) is available in your environment."
+            )  # noqa: E501
             logging.error("Please check your config and try again. Error: %s", exc)  # noqa: E501
             sys.exit(1)
     return result

--- a/prismacloud/cli/cspm/cmd_saas_version.py
+++ b/prismacloud/cli/cspm/cmd_saas_version.py
@@ -20,5 +20,5 @@ def cli(ctx):
         except AttributeError:
             pass
     compute_version = pc_api.get_endpoint("version", api="cwpp")
-    version = {"cspm_tag":  version_tag, "cspm_sha": version_sha, "cwpp_version": compute_version}
+    version = {"cspm_tag": version_tag, "cspm_sha": version_sha, "cwpp_version": compute_version}
     cli_output(version)

--- a/prismacloud/cli/cwpp/cmd_host_auto_deploy.py
+++ b/prismacloud/cli/cwpp/cmd_host_auto_deploy.py
@@ -22,17 +22,13 @@ def host_auto_deploy_read():
 @click.option(
     "--provider",
     default="aws",
-    type=click.Choice(
-        ["aws", "azure", "gcp"]
-    ),
+    type=click.Choice(["aws", "azure", "gcp"]),
     help="Cloud Service Provider",
 )
 @click.option(
     "--aws_region_type",
     default="regular",
-    type=click.Choice(
-        ["regular", "government", "china"]
-    ),
+    type=click.Choice(["regular", "government", "china"]),
     help="Scanning scope",
 )
 @click.option(
@@ -59,8 +55,8 @@ def host_auto_deploy_update(provider, aws_region_type, bucket_region, console_ho
     credentials = pc_api.get_endpoint("credentials?cloud=true")
     for credential in credentials:
         if credential["type"] == provider and credential["useAWSRole"] is False:
-            logging.info("API - Found Credential: %s", credential['_id'])
-            cloud_accounts.append(credential['_id'])
+            logging.info("API - Found Credential: %s", credential["_id"])
+            cloud_accounts.append(credential["_id"])
 
     body_params = []
     if cloud_accounts:
@@ -70,9 +66,9 @@ def host_auto_deploy_update(provider, aws_region_type, bucket_region, console_ho
         collections = pc_api.get_endpoint("collections")
         for collection in collections:
             if collection["name"] == collection_name:
-                del collection['system']
-                del collection['prisma']
-                del collection['modified']
+                del collection["system"]
+                del collection["prisma"]
+                del collection["modified"]
                 cloud_collection = collection
                 logging.info("API - Found collection: %s", cloud_collection)
 
@@ -101,9 +97,7 @@ def host_auto_deploy_update(provider, aws_region_type, bucket_region, console_ho
 @click.option(
     "--provider",
     default="aws",
-    type=click.Choice(
-        ["aws", "azure", "gcp"]
-    ),
+    type=click.Choice(["aws", "azure", "gcp"]),
     help="Cloud Service Provider",
 )
 @click.option(
@@ -117,9 +111,7 @@ def host_auto_deploy_update(provider, aws_region_type, bucket_region, console_ho
 @click.option(
     "--aws_region_type",
     default="regular",
-    type=click.Choice(
-        ["regular", "government", "china"]
-    ),
+    type=click.Choice(["regular", "government", "china"]),
     help="Scanning scope",
 )
 @click.option(
@@ -146,9 +138,9 @@ def host_auto_deploy_create(provider, name, credential_id, aws_region_type, buck
     collections = pc_api.get_endpoint("collections")
     for collection in collections:
         if collection["name"] == collection_name:
-            del collection['system']
-            del collection['prisma']
-            del collection['modified']
+            del collection["system"]
+            del collection["prisma"]
+            del collection["modified"]
             cloud_collection = collection
             logging.info("API - Found collection: %s", cloud_collection)
 

--- a/prismacloud/cli/cwpp/cmd_images.py
+++ b/prismacloud/cli/cwpp/cmd_images.py
@@ -33,8 +33,8 @@ def packages_(limit=50):
         for package in i["packages"]:
             # Go through list of packages
             for p_in_image in package["pkgs"]:
-                p_in_image['image_id'] = i['id']
-                p_in_image['image_tag'] = i['repoTag']['registry'] + "/" + i['repoTag']['repo'] + ":" + i['repoTag']['tag']
+                p_in_image["image_id"] = i["id"]
+                p_in_image["image_tag"] = i["repoTag"]["registry"] + "/" + i["repoTag"]["repo"] + ":" + i["repoTag"]["tag"]
                 package_list.append(p_in_image)
 
     cli_output(package_list)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coloredlogs
 datetime
 jsondiff
 pandas
-prismacloud-api==5.0.0
+prismacloud-api==5.0.2
 pydantic
 requests
 tabulate

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coloredlogs
 datetime
 jsondiff
 pandas
-prismacloud-api==4.2.1
+prismacloud-api==5.0.0
 pydantic
 requests
 tabulate

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "update_checker",
         "pydantic",
         "datetime",
-        "prismacloud-api==4.2.1",
+        "prismacloud-api==5.0.0",
     ],
     name="prismacloud-cli",
     version=version,

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "update_checker",
         "pydantic",
         "datetime",
-        "prismacloud-api==5.0.0",
+        "prismacloud-api==5.0.2",
     ],
     name="prismacloud-cli",
     version=version,


### PR DESCRIPTION
## Description

Refactor for compatibility with the proposed `prismacloud-api` package version 5.0.0.

Depends upon: https://github.com/PaloAltoNetworks/prismacloud-api-python/pull/99

## Motivation and Context

Create the potential to merge the prismacloud-api package with the `pcpi` package:

https://github.com/PaloAltoNetworks/pc-python-integration

Clean up misleading configuration names, like specifying a `username` in `access_key_id`.

Allow configuration of just one API URL with SaaS (which can auto-configure its Compute API URL). 

## How Has This Been Tested?

pylint (I'm not familiar with this packages testing methodology.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
