### PR TITLE
Improved console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ pc --columns hostname,repoTag.repo,osDistro -o csv images -l 1
 
 ## Environment variables
 
-To overwrite the default output settings, use environment variables MAX_WIDTH (console output), MAX_ROWS and MAX_COLUMNS.
+To overwrite the default output settings, use environment variables MAX_WIDTH (console output), MAX_ROWS, MAX_COLUMNS and MAX_LINES. 
+
+- MAX_LINES is used to defined the maximum number of lines within a cell when wrapping the contents.
 
 ## Commands
 The cli has several commands to work with, see the screenshot below for an example, but use ```pc --help``` to see the latest list for your version.

--- a/bin/pc
+++ b/bin/pc
@@ -8,6 +8,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from prismacloud.cli import cli
 
 if __name__ == '__main__':
-    print(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    #print(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
     sys.exit(cli())

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -313,16 +313,17 @@ def cli_output(data, sort_values=False):
     # Generate and show the output
     show_output(data_frame, params, data)
 
+
 def wrap_text(text):
     """Truncate a string to max_width characters"""
-
     try:
         wrapped_text = str(text)
-        wrapped_text = textwrap.fill(text=wrapped_text, width=settings.max_width, max_lines=5)
+        wrapped_text = textwrap.fill(text=wrapped_text, width=settings.max_width, max_lines=10)
         return wrapped_text
     except Exception as _exc:  # pylint:disable=broad-except
         logging.debug("Error truncating: %s", _exc)
         return text
+
 
 def show_output(data_frame, params, data):
     try:

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -5,6 +5,7 @@ import os
 import sys
 import warnings
 import re
+import textwrap
 
 import click
 import click_completion
@@ -13,7 +14,6 @@ import pandas as pd
 from click_help_colors import HelpColorsMultiCommand
 from pydantic import BaseSettings
 from tabulate import tabulate
-import textwrap
 from update_checker import UpdateChecker
 
 import prismacloud.cli.version as cli_version

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -317,9 +317,24 @@ def cli_output(data, sort_values=False):
 def wrap_text(text):
     """Truncate a string to max_width characters"""
     try:
-        wrapped_text = str(text)
-        wrapped_text = textwrap.fill(text=wrapped_text, width=settings.max_width, max_lines=10)
-        return wrapped_text
+        if isinstance(text, list):
+            wrapped_text = ''
+            for item in text:
+                wrapped_text += textwrap.fill(text=item, width=settings.max_width, max_lines=10) + '\n'
+            return wrapped_text
+
+        elif isinstance(text, dict):
+            if 'name' in text:
+                wrapped_text = ''
+                for item in text['name']:
+                    wrapped_text += item + '\n'
+                return wrapped_text
+            else:
+                wrapped_text = textwrap.fill(text=text, width=settings.max_width, max_lines=10)
+                return wrapped_text
+        else:
+            wrapped_text = textwrap.fill(text=text, width=settings.max_width, max_lines=10)
+            return wrapped_text
     except Exception as _exc:  # pylint:disable=broad-except
         logging.debug("Error truncating: %s", _exc)
         return text
@@ -335,7 +350,7 @@ def show_output(data_frame, params, data):
             data_frame_truncated = data_frame.applymap(wrap_text, na_action="ignore")
 
             # Wrap column names
-            data_frame_truncated.columns = list(map(wrap_text,data_frame_truncated.columns))
+            data_frame_truncated.columns = list(map(wrap_text, data_frame_truncated.columns))
 
             table_output = tabulate(
                 data_frame_truncated, headers="keys", tablefmt="fancy_grid", showindex=False)

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):  # pylint:disable=too-few-public-methods
     max_rows: int = 1000000
     max_width: int = 25
     max_levels: int = 2
+    max_lines: int = 10
 
     url: str = False
     identity: str = False
@@ -320,7 +321,7 @@ def wrap_text(text):
         if isinstance(text, list):
             wrapped_text = ''
             for item in text:
-                wrapped_text += textwrap.fill(text=item, width=settings.max_width, max_lines=10) + '\n'
+                wrapped_text += textwrap.fill(text=item, width=settings.max_width, max_lines=settings.max_lines) + '\n'
             return wrapped_text
 
         elif isinstance(text, dict):
@@ -330,10 +331,10 @@ def wrap_text(text):
                     wrapped_text += item + '\n'
                 return wrapped_text
             else:
-                wrapped_text = textwrap.fill(text=text, width=settings.max_width, max_lines=10)
+                wrapped_text = textwrap.fill(text=text, width=settings.max_width, max_lines=settings.max_lines)
                 return wrapped_text
         else:
-            wrapped_text = textwrap.fill(text=text, width=settings.max_width, max_lines=10)
+            wrapped_text = textwrap.fill(text=text, width=settings.max_width, max_lines=settings.max_lines)
             return wrapped_text
     except Exception as _exc:  # pylint:disable=broad-except
         logging.debug("Error truncating: %s", _exc)

--- a/prismacloud/cli/version.py
+++ b/prismacloud/cli/version.py
@@ -1,1 +1,1 @@
-version = "0.5.1"
+version = "0.5.2"


### PR DESCRIPTION
## Description

This version has the output improved for readabiility. There is a better table around the cells and it wraps lines within cells if they are more then MAX_WIDTH characters. By default the number of lines in a cell has a maximum of 10, which can be changed with MAX_LINES.

## Motivation and Context

The previous text output was sometimes unreadable and not so useful.

## How Has This Been Tested?

This has been tested manually for readability and automatically with ```make test```.

## Screenshots (if appropriate)

### Previous output
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/96180461/212848258-5b0ff399-6099-4e0b-b6fc-baf6ed5cbab5.png">

### New output
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/96180461/212848115-741cb858-b6d1-4ddd-ade1-18fe859f2a1d.png">

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
