### PR TITLE
Added markdown and clipboard outputs

### DIFF
--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -365,7 +365,16 @@ def show_output(data_frame, params, data):
         if params["output"] == "clipboard":
             click.secho(data_frame.to_clipboard(index=False), fg="green")
         if params["output"] == "markdown":
-            click.secho(data_frame.to_markdown(index=False), fg="green")
+            # Drop all but first settings.max_columns columns from data_frame
+            data_frame.drop(data_frame.columns[settings.max_columns:], axis=1, inplace=True)
+
+            # Wrap all cells
+            data_frame_truncated = data_frame.applymap(wrap_text, na_action="ignore")
+
+            # Wrap column names
+            data_frame_truncated.columns = list(map(wrap_text, data_frame_truncated.columns))
+
+            click.secho(data_frame_truncated.to_markdown(index=False), fg="green")
         if params["output"] == "html":
             # pre-table-html
             pre_table_html = """

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -155,7 +155,8 @@ Prisma Cloud CLI (version: {0})
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
 @click.option("-vv", "--very_verbose", is_flag=True, help="Enables very verbose mode")
 @click.option("--filter", "query_filter", help="Add search filter")
-@click.option("-o", "--output", type=click.Choice(["text", "csv", "json", "html", "clipboard", "markdown", "columns"]), default="text")
+@click.option("-o", "--output",
+              type=click.Choice(["text", "csv", "json", "html", "clipboard", "markdown", "columns"]), default="text")
 @click.option(
     "-c",
     "--config",
@@ -362,9 +363,9 @@ def show_output(data_frame, params, data):
         if params["output"] == "csv":
             click.secho(data_frame.to_csv(index=False), fg="green")
         if params["output"] == "clipboard":
-            click.secho(data_frame.to_clipboard(index=False), fg="green")   
+            click.secho(data_frame.to_clipboard(index=False), fg="green")
         if params["output"] == "markdown":
-            click.secho(data_frame.to_markdown(index=False), fg="green")       
+            click.secho(data_frame.to_markdown(index=False), fg="green")
         if params["output"] == "html":
             # pre-table-html
             pre_table_html = """

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -155,7 +155,7 @@ Prisma Cloud CLI (version: {0})
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
 @click.option("-vv", "--very_verbose", is_flag=True, help="Enables very verbose mode")
 @click.option("--filter", "query_filter", help="Add search filter")
-@click.option("-o", "--output", type=click.Choice(["text", "csv", "json", "html", "columns"]), default="text")
+@click.option("-o", "--output", type=click.Choice(["text", "csv", "json", "html", "clipboard", "columns"]), default="text")
 @click.option(
     "-c",
     "--config",
@@ -361,6 +361,8 @@ def show_output(data_frame, params, data):
             click.secho(data_frame.to_json(orient="records"), fg="green")
         if params["output"] == "csv":
             click.secho(data_frame.to_csv(index=False), fg="green")
+        if params["output"] == "clipboard":
+            click.secho(data_frame.to_clipboard(index=False), fg="green")        
         if params["output"] == "html":
             # pre-table-html
             pre_table_html = """

--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -155,7 +155,7 @@ Prisma Cloud CLI (version: {0})
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose mode")
 @click.option("-vv", "--very_verbose", is_flag=True, help="Enables very verbose mode")
 @click.option("--filter", "query_filter", help="Add search filter")
-@click.option("-o", "--output", type=click.Choice(["text", "csv", "json", "html", "clipboard", "columns"]), default="text")
+@click.option("-o", "--output", type=click.Choice(["text", "csv", "json", "html", "clipboard", "markdown", "columns"]), default="text")
 @click.option(
     "-c",
     "--config",
@@ -362,7 +362,9 @@ def show_output(data_frame, params, data):
         if params["output"] == "csv":
             click.secho(data_frame.to_csv(index=False), fg="green")
         if params["output"] == "clipboard":
-            click.secho(data_frame.to_clipboard(index=False), fg="green")        
+            click.secho(data_frame.to_clipboard(index=False), fg="green")   
+        if params["output"] == "markdown":
+            click.secho(data_frame.to_markdown(index=False), fg="green")       
         if params["output"] == "html":
             # pre-table-html
             pre_table_html = """


### PR DESCRIPTION
## Description

Added outputs for markdown and clipboard.

## Motivation and Context

With these additional outputs, you have more possibilities for data processing outside of the CLI. For example, extracting some data for documentation when markdown is used. Or, for copying the results to your clipboard and pasting them in MS Excel or Google Docs/Sheets.

## How Has This Been Tested?

This has been tested manually.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/96180461/213391975-d8862909-9d3f-4378-8cc9-54dae023044b.png)

![image](https://user-images.githubusercontent.com/96180461/213392273-6fd011d1-e93f-480f-beac-614549abe729.png)


## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
