### PR TITLE
Added option to update policies status based on CSV

### DIFF
--- a/prismacloud/cli/cspm/cmd_policy.py
+++ b/prismacloud/cli/cspm/cmd_policy.py
@@ -83,8 +83,6 @@ def enable_or_disable_policies(
     changes_true_to_false = 0
     changes_false_to_true = 0
 
-
-
     # Ensure that the --dry-run flag is only used in conjunction with the --csv option.
     if dry_run and not csv_file:
         logging.error("The --dry-run option is only valid when --csv is provided.")
@@ -124,8 +122,10 @@ def enable_or_disable_policies(
                     else:
                         try:
                             pc_api.policy_status_update(policy_id, required_status.lower())
-                        except:
-                            logging.error(f"Unable to update Policy ID: {policy_id}. It may have been changed in the past 4 hours.")
+                        except Exception as exc:  # pylint:disable=broad-except
+                            logging.error(
+                                f"Unable to update Policy ID: {policy_id}. It may have been changed in the past 4 hours.")
+                            logging.info("Error:: %s", exc)
                 else:
                     if dry_run:
                         policies_no_change += 1  # Increment if no change is needed
@@ -140,7 +140,13 @@ def enable_or_disable_policies(
             logging.info(f"{Fore.MAGENTA}=== DRY-RUN COMPLETE ==={Style.RESET_ALL}")
             logging.info(f"{Fore.CYAN}Total Policies Fetched: {total_fetched_policies}{Style.RESET_ALL}")
             logging.info(f"{Fore.CYAN}Policies in CSV: {total_policies_csv}{Style.RESET_ALL}")
-            logging.info(f"{Fore.LIGHTGREEN_EX}To Update: {policies_to_update} ({Fore.LIGHTRED_EX}Disabling: {changes_true_to_false}, {Fore.LIGHTGREEN_EX}Enabling: {changes_false_to_true}){Style.RESET_ALL}")
+            logging.info(
+                f"{Fore.LIGHTGREEN_EX}To Update: {policies_to_update} "
+                f"({Fore.LIGHTRED_EX}Disabling: {changes_true_to_false}, "
+                f"{Fore.LIGHTGREEN_EX}Enabling: {changes_false_to_true})"
+                f"{Style.RESET_ALL}"
+            )
+
             logging.info(f"{Fore.LIGHTYELLOW_EX}No Changes: {policies_no_change}{Style.RESET_ALL}")
         else:
             logging.info("API - All policies from CSV have been updated.")

--- a/prismacloud/cli/cspm/cmd_policy.py
+++ b/prismacloud/cli/cspm/cmd_policy.py
@@ -1,9 +1,19 @@
 import logging
 
+import csv
+from colorama import Fore, Style
 import click
+
 
 from prismacloud.cli import cli_output, pass_environment
 from prismacloud.cli.api import pc_api
+
+
+def validate_csv(ctx, param, value):
+    if value:
+        if not value.name.endswith('.csv'):
+            raise click.BadParameter("CSV file extension must be '.csv'")
+        return value
 
 
 @click.group("policy", short_help="[CSPM] Returns available policies, both system default and custom.")
@@ -19,6 +29,18 @@ def list_policies():
 
 
 @click.command("set", short_help="[CSPM] Turn on and off policies")
+@click.option(
+    "--csv",
+    "csv_file",  # Add this line to map the option to the parameter
+    type=click.File('r'),
+    callback=validate_csv,
+    help="CSV file containing policyId and enabled columns."
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Preview changes without actually making them."
+)
 @click.option(
     "--policy_severity",
     default="high",
@@ -42,13 +64,90 @@ def list_policies():
     help="Enable or disable Policies by Compliance Standard, e.g.: 'CIS v1.4.0 (AWS)'",
 )
 @click.option("--status", type=click.Choice(["enable", "disable"]), help="Policy status to set (enable or disable).")
-def enable_or_disable_policies(policy_severity, all_policies, cloud_type, policy_type, status, compliance_standard):
+def enable_or_disable_policies(
+    policy_severity, all_policies, cloud_type,
+    policy_type, status, compliance_standard,
+    csv_file, dry_run
+):
     """Enable or Disable policies"""
+
+    logging.debug("API - Getting list of Policies ...")
+    policy_list = pc_api.policy_v2_list_read()
+    logging.debug("API - All policies have been fetched.")
+
+    # Initialize counters to keep track of planned actions
+    total_fetched_policies = len(policy_list)  # Count the total number of fetched policies
+    total_policies_csv = 0
+    policies_to_update = 0
+    policies_no_change = 0
+    changes_true_to_false = 0
+    changes_false_to_true = 0
+
+
+
+    # Ensure that the --dry-run flag is only used in conjunction with the --csv option.
+    if dry_run and not csv_file:
+        logging.error("The --dry-run option is only valid when --csv is provided.")
+        return
+
+    if dry_run:
+        logging.info(f"{Fore.MAGENTA}=== DRY-RUN SUMMARY ==={Style.RESET_ALL}")
+
+    # When --csv is provided, the function follows a different logic path for updating policies,
+    # and the --status option becomes optional.
+    if csv_file:
+        logging.debug("Processing CSV file: %s", csv_file.name)
+        reader = csv.DictReader(csv_file)  # Use csv directly as file object
+        for row in reader:
+            total_policies_csv += 1  # Increment total count for each row in CSV
+            policy_id = row.get("policyId")
+            required_status = row.get("enabled").lower() == "true"
+            policy = next((p for p in policy_list if p["policyId"] == policy_id), None)
+            logging.debug(f"Policy ID: {policy_id}, ({policy['enabled']}->{required_status}), Name: {policy['name']}")
+            if policy:
+                if policy["enabled"] != required_status:
+                    logging.debug(f"API - Updating Policy:, ({policy['enabled']}->{required_status}), Name: {policy['name']}")
+
+                    if dry_run:
+                        # Check if the policy's current status matches the required status
+                        if policy["enabled"] != required_status:
+                            policies_to_update += 1
+                            action = "-" if policy["enabled"] else "+"
+                            if action == "-":
+                                changes_true_to_false += 1
+                            else:
+                                changes_false_to_true += 1
+
+                            # Log the planned action with color coding
+                            color = Fore.LIGHTGREEN_EX if action == "+" else Fore.LIGHTRED_EX
+                            logging.info(f"{color}[{action}] Policy: {policy['name']}{Style.RESET_ALL}")
+                    else:
+                        try:
+                            pc_api.policy_status_update(policy_id, required_status.lower())
+                        except:
+                            logging.error(f"Unable to update Policy ID: {policy_id}. It may have been changed in the past 4 hours.")
+                else:
+                    if dry_run:
+                        policies_no_change += 1  # Increment if no change is needed
+
+                        # Log that no changes are needed for this policy
+                        action = "="
+                        color = Fore.LIGHTYELLOW_EX if action == "=" else Fore.CYAN
+                        logging.info(f"{color}[{action}] Policy: {policy['name']}{Style.RESET_ALL}")
+
+        # Show summary of actions based on CSV input
+        if dry_run and csv_file:
+            logging.info(f"{Fore.MAGENTA}=== DRY-RUN COMPLETE ==={Style.RESET_ALL}")
+            logging.info(f"{Fore.CYAN}Total Policies Fetched: {total_fetched_policies}{Style.RESET_ALL}")
+            logging.info(f"{Fore.CYAN}Policies in CSV: {total_policies_csv}{Style.RESET_ALL}")
+            logging.info(f"{Fore.LIGHTGREEN_EX}To Update: {policies_to_update} ({Fore.LIGHTRED_EX}Disabling: {changes_true_to_false}, {Fore.LIGHTGREEN_EX}Enabling: {changes_false_to_true}){Style.RESET_ALL}")
+            logging.info(f"{Fore.LIGHTYELLOW_EX}No Changes: {policies_no_change}{Style.RESET_ALL}")
+        else:
+            logging.info("API - All policies from CSV have been updated.")
+        return
+
     specified_policy_status = bool(status.lower() == "enable")
     specified_policy_status_string = str(specified_policy_status).lower()
-    logging.info("API - Getting list of Policies ...")
-    policy_list = pc_api.policy_v2_list_read()
-    logging.info("API - All policies have been fetched.")
 
     policy_list_to_update = []
     if compliance_standard is not None:


### PR DESCRIPTION
## Description

Added the option --csv to the policy set command to be able to import and parse a CSV file for enabling and disabling policies at scale.

## Motivation and Context

Questions have been asked to update out-of-the-box policies statuses based on a CSV file. This addition makes it possible to use a CSV file with only the policies you want to update and their status.

To get an example, use the command below to extract policies and create the CSV.

`pc -o csv --columns policyId,enabled,^name$ policy list|head -n 5 > ~/policies.csv`

Use this CSV to make changes (e.g. enable or disable policies by either using True or False).

```
policyId,name,enabled
82908c8a-6bb8-4c63-b4b5-24967c9f7145,S3 bucket MFA Delete is not enabled,True
ca524b38-306c-4482-8700-b3717189003b,Unauthorized account access risk through a publicly exposed AWS Lambda function with no authentication and excessive IAM permissions,False
028a45a7-ad8d-48f3-9012-2417defd324b,Azure Microsoft Defender for Cloud set to Off for DNS,True
91c941aa-d110-4b33-9934-aadd86b1a4d9,AWS Redshift database does not have audit logging enabled,False
```

To parse the CSV and update the policies accordingly, use:

`python3 bin/pc -v policy set --csv ~/policies.csv`

## How Has This Been Tested?

You can execute a dry-run with `--dry-run`, e.g.:

`python3 bin/pc -v policy set --csv ~/policies.csv --dry-run`

## Screenshots 

By default and without `-v` or `-vv` there is no output. When using `--dry-run` you will see an overview of changes that would have been made without `--dry-run`.

<img width="1227" alt="image" src="https://github.com/PaloAltoNetworks/prismacloud-cli/assets/96180461/eb6af137-37a7-4d32-9773-8319d78a81ef">

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
