### PR TITLE
Updated prismacloud/cli/__init__.py, changed Bootstrap to current 5.3.2 

### DIFF
--- a/prismacloud/cli/__init__.py
+++ b/prismacloud/cli/__init__.py
@@ -415,8 +415,10 @@ def show_output(data_frame, params, data):
 
 <html>
 <head>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+
 </head>
+<body>
                 """  # noqa
             click.secho(pre_table_html)
             click.secho(
@@ -432,7 +434,8 @@ def show_output(data_frame, params, data):
             # post-table-html
             post_table_html = """
 
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/js/bootstrap.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+</body>
 </html>
 
                 """  # noqa


### PR DESCRIPTION
## Description
Updated prismacloud/cli/__init__.py, changed Bootstrap to current 5.3.2.  
Before the change we were using Bootstrap 4.0 for the CSS  and Bootstrap 3.x for the Javascript

## Motivation and Context

This change was implemented in order to bring libraries (Bootstrap) up to date.

## How Has This Been Tested?
Executed pc command with -o html option.

## Screenshots (if appropriate)

![image](https://github.com/PaloAltoNetworks/prismacloud-cli/assets/9271237/4d4cdb16-3594-4ee6-adf6-e518c9f6e4a8)

## Types of changes

- Bug fix (non-breaking change which fixes an issue) - Library update

## Checklist

- [x] I have updated the documentation accordingly.  - Not needed
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [?] All new and existing tests passed.
        - pylint reporting that it isn't finding modules (fatal)
        - flake8 not showing any issues
        - black not showing any issues