### PR TITLE
Feature/appsec add suppressions

### DIFF
--- a/prismacloud/cli/pccs/cmd_repositories.py
+++ b/prismacloud/cli/pccs/cmd_repositories.py
@@ -24,7 +24,7 @@ class MyHelper:
         return flat_list
 
 
-@click.group("repositories", short_help="[PCCS] Interact with repositories")
+@click.group("repositories", short_help="[APPSEC] Interact with repositories")
 @pass_environment
 def cli(ctx):
     pass

--- a/prismacloud/cli/pccs/cmd_reviews.py
+++ b/prismacloud/cli/pccs/cmd_reviews.py
@@ -4,7 +4,7 @@ from prismacloud.cli import cli_output, pass_environment
 from prismacloud.cli.api import pc_api
 
 
-@click.group("reviews", short_help="Get Code review runs data")
+@click.group("reviews", short_help="[APPSEC] Get Code review runs data")
 @pass_environment
 def cli(ctx):
     pass

--- a/prismacloud/cli/pccs/cmd_suppressions.py
+++ b/prismacloud/cli/pccs/cmd_suppressions.py
@@ -85,65 +85,62 @@ def list_justifications():
             "terraformEnterprise",
         ]
     ),
-    required=True, 
+    required=True,
     help="Type of the integration to update",
 )
-@click.option("-r","--repository", required=True, help="Repository Name. e.g.: 'SimOnPanw/my-terragoat'")
-@click.option("-f","--files", multiple=True, help="File Name. Can specify multiple. e.g.: '-f s3.tf -f sns.tf'")
-def create(integration_type, repository, files):    
+@click.option("-r", "--repository", required=True, help="Repository Name. e.g.: 'SimOnPanw/my-terragoat'")
+@click.option("-f", "--files", multiple=True, help="File Name. Can specify multiple. e.g.: '-f s3.tf -f sns.tf'")
+def create(integration_type, repository, files):
     """Create new suppression"""
     data = []
     current_date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
     parameters = {}
-    parameters["sourceTypes"] = [integration_type]  
+    parameters["sourceTypes"] = [integration_type]
     parameters["repository"] = repository
-    
-    ## Get all the files that contain errors in them
-    all_repo_file_error_summaries = pc_api.errors_files_list(criteria = parameters)['data']
+
+    # Get all the files that contain errors in them
+    all_repo_file_error_summaries = pc_api.errors_files_list(criteria=parameters)["data"]
 
     for file_summary in all_repo_file_error_summaries:
-        # Process all files if no specific files are provided, 
+        # Process all files if no specific files are provided,
         # or just the specific ones if they are provided and match the current file path
-        if not files or any(file_summary['filePath'].endswith(f) for f in files):
+        if not files or any(file_summary["filePath"].endswith(f) for f in files):
             if files:  # This check ensures we only log for specific files, not all files
                 logging.info(f"Parsing this specific files: {file_summary['filePath']}")
 
-            parameters['filePath'] = file_summary['filePath']
+            parameters["filePath"] = file_summary["filePath"]
             parameters["types"] = ["Errors"]
 
             impacted_files = pc_api.errors_file_list(criteria=parameters)
-            for error_in_file in  impacted_files:
+            for error_in_file in impacted_files:
                 resource_id = f"{error_in_file['errorId']}::{repository}::{error_in_file['resourceId']}"
-                body_data = {  
-                    'comment': f'{current_date} - Suppressed via Prisma Cloud CLI.',  
-                    'origin': 'Platform', 
-                    'resources': { 
-                        'id': resource_id,    
-                        'accountId': repository
-                        },  
-                    'suppressionType': 'Resources'
-                }    
-                try:                            
-                    pc_api.suppressions_create(error_in_file['errorId'], body_data)                    
+                body_data = {
+                    "comment": f"{current_date} - Suppressed via Prisma Cloud CLI.",
+                    "origin": "Platform",
+                    "resources": {"id": resource_id, "accountId": repository},
+                    "suppressionType": "Resources",
+                }
+                try:
+                    pc_api.suppressions_create(error_in_file["errorId"], body_data)
                     data = data + [
                         {
-                            "action": 'Suppresed by Policy',
-                            "policy": error_in_file['errorId'],
+                            "action": "Suppresed by Policy",
+                            "policy": error_in_file["errorId"],
                             "repository": repository,
-                            "file": error_in_file['resourceId'],
-                            "comment": f'{current_date} - Suppressed via Prisma Cloud CLI.',
+                            "file": error_in_file["resourceId"],
+                            "comment": f"{current_date} - Suppressed via Prisma Cloud CLI.",
                         }
                     ]
-                    logging.info(f"Suppression created for {error_in_file['resourceId']} in repository {repository}")                
+                    logging.info(f"Suppression created for {error_in_file['resourceId']} in repository {repository}")
                 except Exception as e:
                     logging.error(f"An error occurred while creating suppression: {e}")
                     data = data + [
                         {
-                            "action": 'Error during suppression',
-                            "policy": error_in_file['errorId'],
+                            "action": "Error during suppression",
+                            "policy": error_in_file["errorId"],
                             "repository": repository,
-                            "file": error_in_file['resourceId'],
-                            "comment": f'{current_date} - Suppressed via Prisma Cloud CLI.',
+                            "file": error_in_file["resourceId"],
+                            "comment": f"{current_date} - Suppressed via Prisma Cloud CLI.",
                         }
                     ]
 

--- a/prismacloud/cli/pccs/cmd_suppressions.py
+++ b/prismacloud/cli/pccs/cmd_suppressions.py
@@ -1,11 +1,12 @@
 import logging
+import datetime
 import click
 
 from prismacloud.cli import cli_output, pass_environment
 from prismacloud.cli.api import pc_api
 
 
-@click.group("suppressions", short_help="List suppression rules")
+@click.group("suppressions", short_help="[APPSEC] List suppression rules")
 @pass_environment
 def cli(ctx):
     pass
@@ -56,5 +57,99 @@ def list_justifications():
     cli_output(data)
 
 
+@click.command("create", short_help="Create new suppression")
+@click.option(
+    "-i",
+    "--integration-type",
+    type=click.Choice(
+        [
+            "Github",
+            "Bitbucket",
+            "Gitlab",
+            "AzureRepos",
+            "cli",
+            "AWS",
+            "Azure",
+            "GCP",
+            "Docker",
+            "githubEnterprise",
+            "gitlabEnterprise",
+            "bitbucketEnterprise",
+            "terraformCloud",
+            "githubActions",
+            "circleci",
+            "codebuild",
+            "jenkins",
+            "tfcRunTasks",
+            "admissionController",
+            "terraformEnterprise",
+        ]
+    ),
+    required=True, 
+    help="Type of the integration to update",
+)
+@click.option("-r","--repository", required=True, help="Repository Name. e.g.: 'SimOnPanw/my-terragoat'")
+@click.option("-f","--files", multiple=True, help="File Name. Can specify multiple. e.g.: '-f s3.tf -f sns.tf'")
+def create(integration_type, repository, files):    
+    """Create new suppression"""
+    data = []
+    current_date = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+    parameters = {}
+    parameters["sourceTypes"] = [integration_type]  
+    parameters["repository"] = repository
+    
+    ## Get all the files that contain errors in them
+    all_repo_file_error_summaries = pc_api.errors_files_list(criteria = parameters)['data']
+
+    for file_summary in all_repo_file_error_summaries:
+        # Process all files if no specific files are provided, 
+        # or just the specific ones if they are provided and match the current file path
+        if not files or any(file_summary['filePath'].endswith(f) for f in files):
+            if files:  # This check ensures we only log for specific files, not all files
+                logging.info(f"Parsing this specific files: {file_summary['filePath']}")
+
+            parameters['filePath'] = file_summary['filePath']
+            parameters["types"] = ["Errors"]
+
+            impacted_files = pc_api.errors_file_list(criteria=parameters)
+            for error_in_file in  impacted_files:
+                resource_id = f"{error_in_file['errorId']}::{repository}::{error_in_file['resourceId']}"
+                body_data = {  
+                    'comment': f'{current_date} - Suppressed via Prisma Cloud CLI.',  
+                    'origin': 'Platform', 
+                    'resources': { 
+                        'id': resource_id,    
+                        'accountId': repository
+                        },  
+                    'suppressionType': 'Resources'
+                }    
+                try:                            
+                    pc_api.suppressions_create(error_in_file['errorId'], body_data)                    
+                    data = data + [
+                        {
+                            "action": 'Suppresed by Policy',
+                            "policy": error_in_file['errorId'],
+                            "repository": repository,
+                            "file": error_in_file['resourceId'],
+                            "comment": f'{current_date} - Suppressed via Prisma Cloud CLI.',
+                        }
+                    ]
+                    logging.info(f"Suppression created for {error_in_file['resourceId']} in repository {repository}")                
+                except Exception as e:
+                    logging.error(f"An error occurred while creating suppression: {e}")
+                    data = data + [
+                        {
+                            "action": 'Error during suppression',
+                            "policy": error_in_file['errorId'],
+                            "repository": repository,
+                            "file": error_in_file['resourceId'],
+                            "comment": f'{current_date} - Suppressed via Prisma Cloud CLI.',
+                        }
+                    ]
+
+    cli_output(data)
+
+
+cli.add_command(create)
 cli.add_command(list_suppressions)
 cli.add_command(list_justifications)

--- a/prismacloud/cli/version.py
+++ b/prismacloud/cli/version.py
@@ -1,1 +1,1 @@
-version = "0.7.6"
+version = "0.7.7"


### PR DESCRIPTION
## Description

Implement Prisma Cloud Suppression Feature
Added functionality to create suppressions for errors in specified files on Prisma Cloud. 
The update includes checks for file-specific suppressions and handles exceptions gracefully.

Here is how to use the new suppressions feature:
`pc suppressions create -i Github -r git-SimOnPanw/terragoat -f gcp/big_data.tf -f aws/s3.tf `

To export in JSON:
`pc -ojson suppressions create -i Github -r git-SimOnPanw/terragoat -f gcp/big_data.tf -f aws/s3.tf | jq . `

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

Add suppressions for AppSec.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
