### PR TITLE
Add container registry listing and scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,34 @@ Get all drift across all Github repositories:
 ```
 pc repositories search --integration_type Github --categories Drift
 ```
+
+
+### Container registries  
+
+#### Listing registries
+To list all container registries:  
+
+```bash
+pc registry list
+```
+
+#### Triggering Scans
+To trigger scans on all registries:
+
+```bash
+pc registry scan
+```
+
+#### Including Specific Registries
+To include specific registries or repositories in the scan:
+
+```bash
+pc registry scan --include "registry_name/repo_name" --i "another_registry"
+```
+
+#### Excluding Specific Registries
+To exclude specific registries or repositories from the scan:
+
+```bash
+pc registry scan --exclude "registry_name/repo_name" --e "another_registry"
+```

--- a/prismacloud/cli/cwpp/cmd_registry.py
+++ b/prismacloud/cli/cwpp/cmd_registry.py
@@ -4,16 +4,16 @@ from prismacloud.cli import cli_output, pass_environment
 from prismacloud.cli.api import pc_api
 
 
-@click.group("cwpp_registry", short_help="[CWPP] Scan reports for images in your registry.")
+@click.group("registry", short_help="[CWPP] Scan reports for images in your registry.")
 @pass_environment
 def cli(ctx):
     pass
 
 
-@click.command()
+@click.command("images", short_help="Retrieves registry image scan reports.")
 @click.option("--field", default="")
-def runtimecontainer(field=""):
-    result = pc_api.get_endpoint("registry")
+def images(field=""):
+    result = pc_api.registry_list_read("registry")
 
     if field == "":
         cli_output(result)
@@ -28,4 +28,130 @@ def runtimecontainer(field=""):
         cli_output(result)
 
 
-cli.add_command(runtimecontainer)
+@click.command("list", short_help="Retrieves the list of registries Prisma Cloud is configured to scan. ")
+@click.option(
+    "--include", 
+    "-i", 
+    multiple=True, 
+    help="Include a registry, a repository, or both for the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
+    default=[]
+)
+@click.option(
+    "--exclude", 
+    "-e", 
+    multiple=True, 
+    help="Exclude a registry, a repository, or both from the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
+    default=[]
+)
+def list(include, exclude):     
+    registries_to_scan = []
+    registries = pc_api.settings_registry_read()
+    for registry_item in registries['specifications']:
+        registries_to_scan.append({'registry': registry_item['registry'], 'repo': registry_item['repository'], 'tag': registry_item['tag']})
+    if exclude:   
+        # Later in your main function, when processing registries to scan:
+        excluded_registries = [normalize_registry_name(e) for e in exclude]  # Prepare the list of normalized exclusions
+        registries_to_scan = [r for r in registries_to_scan if not is_excluded(r, excluded_registries)]
+
+    
+    # Filter registries based on inclusion criteria if any are specified
+    if include:
+        registries_to_scan = [r for r in registries_to_scan if is_included(r, include)]
+
+    cli_output(registries_to_scan)
+
+
+@click.command("scan", short_help="Trigger the scan of registries.")
+@click.option(
+    "--include", 
+    "-i", 
+    multiple=True, 
+    help="Include a registry, a repository, or both for the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
+    default=[]
+)
+@click.option(
+    "--exclude", 
+    "-e", 
+    multiple=True, 
+    help="Exclude a registry, a repository, or both from the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
+    default=[]
+)
+def scan(include, exclude):     
+    registries_to_scan = []
+    registries = pc_api.settings_registry_read()
+    for registry_item in registries['specifications']:
+        registries_to_scan.append({'registry': registry_item['registry'], 'repo': registry_item['repository'], 'tag': registry_item['tag']})
+    if exclude:   
+        # Later in your main function, when processing registries to scan:
+        excluded_registries = [normalize_registry_name(e) for e in exclude]  # Prepare the list of normalized exclusions
+        registries_to_scan = [r for r in registries_to_scan if not is_excluded(r, excluded_registries)]
+
+    
+    # Filter registries based on inclusion criteria if any are specified
+    if include:
+        registries_to_scan = [r for r in registries_to_scan if is_included(r, include)]
+    
+    # Transform each registry to the new format
+    payload = [{"tag": {"registry": r["registry"],
+                                    "repo": r["repo"],
+                                    "tag": r["tag"]}} for r in registries_to_scan]
+
+    pc_api.registry_scan_select(body_params=payload)
+    cli_output(registries_to_scan)
+
+
+
+def normalize_registry_name(registry_name):
+    """Strip 'https://' prefix and trailing slash from registry names for consistent comparison."""
+    normalized_name = registry_name
+    if normalized_name.startswith("https://"):
+        normalized_name = normalized_name[len("https://"):]
+    if normalized_name.endswith("/"):
+        normalized_name = normalized_name[:-1]
+    return normalized_name.lower()  # Consider lowercasing to make comparison case-insensitive
+
+
+def is_excluded(registry, exclusions):
+    """Check if a given registry should be excluded based on the exclusions list."""
+    for exclusion in exclusions:
+        exclusion_normalized = normalize_registry_name(exclusion)
+        registry_normalized = normalize_registry_name(registry['registry'])
+        repo_normalized = registry['repo'].lower()  
+        # Check if the exclusion matches the registry or repository name
+        if exclusion_normalized in registry_normalized or exclusion_normalized in repo_normalized:
+            return True
+    return False
+
+
+def is_included(registry, inclusions):
+    """Check if a given registry should be included based on the inclusions list."""
+    # If no inclusions are specified, assume everything is included by default
+    if not inclusions:
+        return True
+    
+    for inclusion in inclusions:
+        inclusion_normalized = normalize_registry_name(inclusion)
+        registry_normalized = normalize_registry_name(registry['registry'])
+        repo_normalized = registry['repo'].lower()
+        
+        # Split inclusion criteria in case it specifies both registry and repo
+        if '/' in inclusion_normalized:
+            inclusion_parts = inclusion_normalized.split('/', 1)
+            inclusion_registry = inclusion_parts[0]
+            inclusion_repo = inclusion_parts[1]
+            
+            # Check if both registry and repo match the inclusion criteria
+            if inclusion_registry in registry_normalized and inclusion_repo in repo_normalized:
+                return True
+        else:
+            # If the inclusion criteria is only one part, check both registry and repo for a match
+            if inclusion_normalized in registry_normalized or inclusion_normalized in repo_normalized:
+                return True
+    
+    # If none of the inclusions match, return False
+    return False
+
+
+cli.add_command(images)
+cli.add_command(list)
+cli.add_command(scan)

--- a/prismacloud/cli/cwpp/cmd_registry.py
+++ b/prismacloud/cli/cwpp/cmd_registry.py
@@ -30,30 +30,33 @@ def images(field=""):
 
 @click.command("list", short_help="Retrieves the list of registries Prisma Cloud is configured to scan. ")
 @click.option(
-    "--include", 
-    "-i", 
-    multiple=True, 
-    help="Include a registry, a repository, or both for the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
-    default=[]
+    "--include",
+    "-i",
+    multiple=True,
+    help="Include a registry, a repository, or both for the scan. \
+        Format: registry_name/repo_name, registry_name, or repo_name",
+    default=[],
 )
 @click.option(
-    "--exclude", 
-    "-e", 
-    multiple=True, 
-    help="Exclude a registry, a repository, or both from the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
-    default=[]
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Exclude a registry, a repository, or both from the scan. \
+        Format: registry_name/repo_name, registry_name, or repo_name",
+    default=[],
 )
-def list(include, exclude):     
+def list(include, exclude):
     registries_to_scan = []
     registries = pc_api.settings_registry_read()
-    for registry_item in registries['specifications']:
-        registries_to_scan.append({'registry': registry_item['registry'], 'repo': registry_item['repository'], 'tag': registry_item['tag']})
-    if exclude:   
+    for registry_item in registries["specifications"]:
+        registries_to_scan.append(
+            {"registry": registry_item["registry"], "repo": registry_item["repository"], "tag": registry_item["tag"]}
+        )
+    if exclude:
         # Later in your main function, when processing registries to scan:
         excluded_registries = [normalize_registry_name(e) for e in exclude]  # Prepare the list of normalized exclusions
         registries_to_scan = [r for r in registries_to_scan if not is_excluded(r, excluded_registries)]
 
-    
     # Filter registries based on inclusion criteria if any are specified
     if include:
         registries_to_scan = [r for r in registries_to_scan if is_included(r, include)]
@@ -63,42 +66,42 @@ def list(include, exclude):
 
 @click.command("scan", short_help="Trigger the scan of registries.")
 @click.option(
-    "--include", 
-    "-i", 
-    multiple=True, 
-    help="Include a registry, a repository, or both for the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
-    default=[]
+    "--include",
+    "-i",
+    multiple=True,
+    help="Include a registry, a repository, or both for the scan. \
+        Format: registry_name/repo_name, registry_name, or repo_name",
+    default=[],
 )
 @click.option(
-    "--exclude", 
-    "-e", 
-    multiple=True, 
-    help="Exclude a registry, a repository, or both from the scan. Format: registry_name/repo_name, registry_name, or repo_name", 
-    default=[]
+    "--exclude",
+    "-e",
+    multiple=True,
+    help="Exclude a registry, a repository, or both from the scan. \
+    Format: registry_name/repo_name, registry_name, or repo_name",
+    default=[],
 )
-def scan(include, exclude):     
+def scan(include, exclude):
     registries_to_scan = []
     registries = pc_api.settings_registry_read()
-    for registry_item in registries['specifications']:
-        registries_to_scan.append({'registry': registry_item['registry'], 'repo': registry_item['repository'], 'tag': registry_item['tag']})
-    if exclude:   
+    for registry_item in registries["specifications"]:
+        registries_to_scan.append(
+            {"registry": registry_item["registry"], "repo": registry_item["repository"], "tag": registry_item["tag"]}
+        )
+    if exclude:
         # Later in your main function, when processing registries to scan:
         excluded_registries = [normalize_registry_name(e) for e in exclude]  # Prepare the list of normalized exclusions
         registries_to_scan = [r for r in registries_to_scan if not is_excluded(r, excluded_registries)]
 
-    
     # Filter registries based on inclusion criteria if any are specified
     if include:
         registries_to_scan = [r for r in registries_to_scan if is_included(r, include)]
-    
+
     # Transform each registry to the new format
-    payload = [{"tag": {"registry": r["registry"],
-                                    "repo": r["repo"],
-                                    "tag": r["tag"]}} for r in registries_to_scan]
+    payload = [{"tag": {"registry": r["registry"], "repo": r["repo"], "tag": r["tag"]}} for r in registries_to_scan]
 
     pc_api.registry_scan_select(body_params=payload)
     cli_output(registries_to_scan)
-
 
 
 def normalize_registry_name(registry_name):
@@ -115,8 +118,8 @@ def is_excluded(registry, exclusions):
     """Check if a given registry should be excluded based on the exclusions list."""
     for exclusion in exclusions:
         exclusion_normalized = normalize_registry_name(exclusion)
-        registry_normalized = normalize_registry_name(registry['registry'])
-        repo_normalized = registry['repo'].lower()  
+        registry_normalized = normalize_registry_name(registry["registry"])
+        repo_normalized = registry["repo"].lower()
         # Check if the exclusion matches the registry or repository name
         if exclusion_normalized in registry_normalized or exclusion_normalized in repo_normalized:
             return True
@@ -128,18 +131,18 @@ def is_included(registry, inclusions):
     # If no inclusions are specified, assume everything is included by default
     if not inclusions:
         return True
-    
+
     for inclusion in inclusions:
         inclusion_normalized = normalize_registry_name(inclusion)
-        registry_normalized = normalize_registry_name(registry['registry'])
-        repo_normalized = registry['repo'].lower()
-        
+        registry_normalized = normalize_registry_name(registry["registry"])
+        repo_normalized = registry["repo"].lower()
+
         # Split inclusion criteria in case it specifies both registry and repo
-        if '/' in inclusion_normalized:
-            inclusion_parts = inclusion_normalized.split('/', 1)
+        if "/" in inclusion_normalized:
+            inclusion_parts = inclusion_normalized.split("/", 1)
             inclusion_registry = inclusion_parts[0]
             inclusion_repo = inclusion_parts[1]
-            
+
             # Check if both registry and repo match the inclusion criteria
             if inclusion_registry in registry_normalized and inclusion_repo in repo_normalized:
                 return True
@@ -147,7 +150,7 @@ def is_included(registry, inclusions):
             # If the inclusion criteria is only one part, check both registry and repo for a match
             if inclusion_normalized in registry_normalized or inclusion_normalized in repo_normalized:
                 return True
-    
+
     # If none of the inclusions match, return False
     return False
 

--- a/prismacloud/cli/version.py
+++ b/prismacloud/cli/version.py
@@ -1,1 +1,1 @@
-version = "0.8.3"
+version = "0.8.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coloredlogs
 datetime
 jsondiff
 pandas
-prismacloud-api==5.2.11
+prismacloud-api==5.2.12
 pydantic-settings
 pydantic
 requests

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pydantic",
         "datetime",
         "pyyaml",
-        "prismacloud-api==5.2.11",
+        "prismacloud-api==5.2.12",
         "pytest",
         "pytest-benchmark",
     ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ def check_env_vars_or_credentials_file():
     required_env_vars = {
         "PC_ACCESS_KEY": "access_key_id",
         "PC_SAAS_API_ENDPOINT": "api_endpoint",
-        "PC_SECRET_KEY": "secret_key"
+        "PC_SECRET_KEY": "secret_key",
     }
 
     env_vars_set = all(os.environ.get(env_var) for env_var in required_env_vars)


### PR DESCRIPTION
## Description

Add container registry listing and and trigger a scan.
To list all container registries:  

```bash
pc registry list
```
### Triggering Scans
To trigger scans on all registries:

```bash
pc registry scan
```

### Including Specific Registries
To include specific registries or repositories in the scan:

```bash
pc registry scan --include "registry_name/repo_name" --i "another_registry"
```

### Excluding Specific Registries
To exclude specific registries or repositories from the scan:

```bash
pc registry scan --exclude "registry_name/repo_name" --e "another_registry"
```

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
